### PR TITLE
Add Spotless formatter and CleanThat refactorer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,5 +179,13 @@ spotless {
         indentWithSpaces(4)
         endWithNewline()
     }
+    java {
+        // use AOSP style for 4-character wide indents
+        googleJavaFormat().aosp()
+        // fix formatting of type annotations
+        formatAnnotations()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,9 @@ spotless {
     }
     java {
         targetExclude('**/BuildConstants.java')
+
+        cleanthat()
+
         // use AOSP style for 4-character wide indents
         googleJavaFormat().aosp()
         // fix formatting of type annotations

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,7 @@ spotless {
         endWithNewline()
     }
     java {
+        targetExclude('**/BuildConstants.java')
         // use AOSP style for 4-character wide indents
         googleJavaFormat().aosp()
         // fix formatting of type annotations

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2024.1.1-beta-4"
     id "com.peterabeles.gversion" version "1.10"
+    id "com.diffplug.spotless" version "6.23.3"
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -168,4 +168,6 @@ publishing {
             from components.java
         }
     }
+
+spotless {  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ spotless {
     java {
         targetExclude('**/BuildConstants.java')
 
-        cleanthat()
+        cleanthat().sourceCompatibility(java.sourceCompatibility as String)
 
         // use AOSP style for 4-character wide indents
         googleJavaFormat().aosp()

--- a/build.gradle
+++ b/build.gradle
@@ -169,5 +169,15 @@ publishing {
         }
     }
 
-spotless {  }
+spotless {
+    format 'misc', {
+        // define the files to apply `misc` to
+        target '*gradle*', '.gitattributes', '.gitignore'
+
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        indentWithSpaces(4)
+        endWithNewline()
+    }
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ spotless {
         targetExclude('**/BuildConstants.java')
 
         cleanthat().sourceCompatibility(java.sourceCompatibility as String)
+                .addMutator('AllIncludingDraftSingleMutators').includeDraft(false)
 
         // use AOSP style for 4-character wide indents
         googleJavaFormat().aosp()

--- a/src/main/java/frc/robot/swerve/ModuleIO.java
+++ b/src/main/java/frc/robot/swerve/ModuleIO.java
@@ -22,18 +22,15 @@ public interface ModuleIO {
         return null;
     }
 
-    default void updateOffset(double offset) {
-    }
+    default void updateOffset(double offset) {}
 
-    default void neutralOutput() {
-    }
+    default void neutralOutput() {}
 
     default boolean encoderConnected() {
         return false;
     }
 
-    default void checkModule() {
-    }
+    default void checkModule() {}
 
     @AutoLog
     class SwerveModuleInputs {

--- a/src/main/java/frc/robot/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/swerve/ModuleIOReal.java
@@ -30,8 +30,12 @@ public class ModuleIOReal implements ModuleIO {
     private double angleMotorPosition;
     private double driveMotorVelocitySetpoint;
 
-    public ModuleIOReal(int driveMotorID, int angleMotorID, int encoderID,
-                        double[] motionMagicConfigs, int number) {
+    public ModuleIOReal(
+            int driveMotorID,
+            int angleMotorID,
+            int encoderID,
+            double[] motionMagicConfigs,
+            int number) {
 
         this.driveMotor = new TalonFX(driveMotorID);
         this.angleMotor = new TalonFX(angleMotorID);
@@ -97,7 +101,8 @@ public class ModuleIOReal implements ModuleIO {
         inputs.angleMotorStatorCurrentOverTime = angleStatorChargeUsedCoulomb.get();
         inputs.angleMotorPosition = angleMotor.getSelectedSensorPosition();
         angleMotorPosition = inputs.angleMotorPosition;
-        inputs.angleMotorVelocity = ticksPerMeter.toVelocity(angleMotor.getSelectedSensorVelocity());
+        inputs.angleMotorVelocity =
+                ticksPerMeter.toVelocity(angleMotor.getSelectedSensorVelocity());
 
         inputs.angle = getAngle();
         currentAngle = inputs.angle;
@@ -116,7 +121,9 @@ public class ModuleIOReal implements ModuleIO {
     public void setAngle(double angle) {
         angleSetpoint = AngleUtil.normalize(angle);
         Rotation2d error = new Rotation2d(angle).minus(new Rotation2d(currentAngle));
-        angleMotor.set(TalonFXControlMode.MotionMagic, angleMotorPosition + ticksPerRad.toTicks(error.getRadians()));
+        angleMotor.set(
+                TalonFXControlMode.MotionMagic,
+                angleMotorPosition + ticksPerRad.toTicks(error.getRadians()));
     }
 
     @Override
@@ -136,14 +143,14 @@ public class ModuleIOReal implements ModuleIO {
     public SwerveModulePosition getModulePosition() {
         return new SwerveModulePosition(
                 ticksPerMeter.toUnits(driveMotor.getSelectedSensorPosition()),
-                new Rotation2d(getAngle())
-        );
+                new Rotation2d(getAngle()));
     }
 
     @Override
     public void updateOffset(double offset) {
         angleMotor.setSelectedSensorPosition(
-                ((encoder.getAbsolutePosition() - offset) * 2048) / SwerveConstants.ANGLE_REDUCTION);
+                ((encoder.getAbsolutePosition() - offset) * 2048)
+                        / SwerveConstants.ANGLE_REDUCTION);
     }
 
     @Override

--- a/src/main/java/frc/robot/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/swerve/ModuleIOSim.java
@@ -22,15 +22,17 @@ public class ModuleIOSim implements ModuleIO {
     private double angleSetpoint = 0;
 
     public ModuleIOSim() {
-        driveMotor = new FlywheelSim(
-                DCMotor.getFalcon500(1),
-                1 / SwerveConstants.DRIVE_REDUCTION,
-                SwerveConstants.DriveMotorMomentOfInertia);
+        driveMotor =
+                new FlywheelSim(
+                        DCMotor.getFalcon500(1),
+                        1 / SwerveConstants.DRIVE_REDUCTION,
+                        SwerveConstants.DriveMotorMomentOfInertia);
 
-        angleMotor = new FlywheelSim(
-                DCMotor.getFalcon500(1),
-                1 / SwerveConstants.ANGLE_REDUCTION,
-                SwerveConstants.AngleMotorMomentOfInertia);
+        angleMotor =
+                new FlywheelSim(
+                        DCMotor.getFalcon500(1),
+                        1 / SwerveConstants.ANGLE_REDUCTION,
+                        SwerveConstants.AngleMotorMomentOfInertia);
 
         angleFeedback = new PIDController(3.5, 0, 0, 0.02);
         velocityFeedback = new PIDController(0.5, 0, 0.00, 0.02);
@@ -64,7 +66,8 @@ public class ModuleIOSim implements ModuleIO {
     @Override
     public void setAngle(double angle) {
         angleSetpoint = angle;
-        angleMotorAppliedVoltage = angleFeedback.calculate(MathUtil.angleModulus(currentAngle.get()), angle);
+        angleMotorAppliedVoltage =
+                angleFeedback.calculate(MathUtil.angleModulus(currentAngle.get()), angle);
         angleMotor.setInputVoltage(angleMotorAppliedVoltage);
     }
 

--- a/src/main/java/frc/robot/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/swerve/SwerveConstants.java
@@ -6,16 +6,22 @@ import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
 import edu.wpi.first.math.geometry.Translation2d;
 
 public class SwerveConstants {
-    public static final double[] OFFSETS =
-            {0.5686593642164841, 0.26232458155811456, 0.00854002521350063, 0.5429330635733266};
+    public static final double[] OFFSETS = {
+        0.568_659_364_216_484_1,
+        0.262_324_581_558_114_56,
+        0.008_540_025_213_500_63,
+        0.542_933_063_573_326_6
+    };
 
     public static final double VOLT_COMP_SATURATION = 12;
-    public static final SupplyCurrentLimitConfiguration SUPPLY_CURRENT_LIMIT = new SupplyCurrentLimitConfiguration(true, 50, 0, 0);
-    public static final StatorCurrentLimitConfiguration STATOR_CURRENT_LIMIT = new StatorCurrentLimitConfiguration(true, 50, 0, 0);
+    public static final SupplyCurrentLimitConfiguration SUPPLY_CURRENT_LIMIT =
+            new SupplyCurrentLimitConfiguration(true, 50, 0, 0);
+    public static final StatorCurrentLimitConfiguration STATOR_CURRENT_LIMIT =
+            new StatorCurrentLimitConfiguration(true, 50, 0, 0);
 
-    public static final double robotWidth = 0.512; //[m]
-    public static final double robotLength = 0.67; //[m]
-    public static final double WHEEL_DIAMETER = 0.1023679821; //[m]
+    public static final double robotWidth = 0.512; // [m]
+    public static final double robotLength = 0.67; // [m]
+    public static final double WHEEL_DIAMETER = 0.102_367_982_1; // [m]
     public static final double DRIVE_REDUCTION = (1 / 2.0) * (24.0 / 22.0) * (15.0 / 45.0);
     public static final double ANGLE_REDUCTION = (14.0 / 72.0) * 0.5;
     public static final double DriveMotorMomentOfInertia = 0.025;
@@ -23,16 +29,25 @@ public class SwerveConstants {
 
     // kP, kI, kD, kF, sCurveStrength, cruiseVelocity, acceleration, allowableError,
     // maxIntegralAccum, peakOutput
-    public static final double[] FRONT_LEFT_MOTION_MAGIC_CONFIGS = {1, 0, 0, 0.2, 1, 21288, 25000, 10, 5, 1};
-    public static final double[] FRONT_RIGHT_MOTION_MAGIC_CONFIGS = {1, 0, 0, 0.2, 1, 21288, 25000, 10, 5, 1};
-    public static final double[] REAR_LEFT_MOTION_MAGIC_CONFIGS = {1, 0, 0, 0.2, 1, 21288, 25000, 10, 5, 1};
-    public static final double[] REAR_RIGHT_MOTION_MAGIC_CONFIGS = {1, 0, 0, 0.2, 1, 21288, 25000, 10, 5, 1};
+    public static final double[] FRONT_LEFT_MOTION_MAGIC_CONFIGS = {
+        1, 0, 0, 0.2, 1, 21_288, 25_000, 10, 5, 1
+    };
+    public static final double[] FRONT_RIGHT_MOTION_MAGIC_CONFIGS = {
+        1, 0, 0, 0.2, 1, 21_288, 25_000, 10, 5, 1
+    };
+    public static final double[] REAR_LEFT_MOTION_MAGIC_CONFIGS = {
+        1, 0, 0, 0.2, 1, 21_288, 25_000, 10, 5, 1
+    };
+    public static final double[] REAR_RIGHT_MOTION_MAGIC_CONFIGS = {
+        1, 0, 0, 0.2, 1, 21_288, 25_000, 10, 5, 1
+    };
 
     public static final double[][] motionMagicConfigs = {
-            FRONT_LEFT_MOTION_MAGIC_CONFIGS,
-            FRONT_RIGHT_MOTION_MAGIC_CONFIGS,
-            REAR_LEFT_MOTION_MAGIC_CONFIGS,
-            REAR_RIGHT_MOTION_MAGIC_CONFIGS};
+        FRONT_LEFT_MOTION_MAGIC_CONFIGS,
+        FRONT_RIGHT_MOTION_MAGIC_CONFIGS,
+        REAR_LEFT_MOTION_MAGIC_CONFIGS,
+        REAR_RIGHT_MOTION_MAGIC_CONFIGS
+    };
 
     public static final double DRIVE_kP = 0.005;
     public static final double DRIVE_kI = 0.0;
@@ -43,12 +58,20 @@ public class SwerveConstants {
     public static final double OMEGA_kI = 0.0;
     public static final double OMEGA_kD = 0.0;
 
-    public static final double MAX_X_Y_VELOCITY = 6380.0 / 60.0 * //[m/s]
-            DRIVE_REDUCTION *
-            WHEEL_DIAMETER * Math.PI;
+    public static final double MAX_X_Y_VELOCITY =
+            6380.0
+                    / 60.0
+                    * // [m/s]
+                    DRIVE_REDUCTION
+                    * WHEEL_DIAMETER
+                    * Math.PI;
 
-    public static final double MAX_OMEGA_VELOCITY = MAX_X_Y_VELOCITY / //[m/s]
-            Math.sqrt((robotLength / 2) * (robotLength / 2) + (robotWidth / 2) * (robotWidth / 2));
+    public static final double MAX_OMEGA_VELOCITY =
+            MAX_X_Y_VELOCITY
+                    / // [m/s]
+                    Math.sqrt(
+                            (robotLength / 2) * (robotLength / 2)
+                                    + (robotWidth / 2) * (robotWidth / 2));
 
     public static final TalonFXInvertType CLOCKWISE = TalonFXInvertType.Clockwise;
     public static final TalonFXInvertType COUNTER_CLOCKWISE = TalonFXInvertType.CounterClockwise;
@@ -56,15 +79,16 @@ public class SwerveConstants {
     public static final double NEUTRAL_DEADBAND = 0.15;
     public static final double XBOX_DEADBAND = 0.15;
 
-
     public static final double TICKS_PER_RADIAN = 2048 / ANGLE_REDUCTION / (Math.PI * 2);
-    public static final double TICKS_PER_METER = (2048 / DRIVE_REDUCTION) / (Math.PI * WHEEL_DIAMETER);
+    public static final double TICKS_PER_METER =
+            (2048 / DRIVE_REDUCTION) / (Math.PI * WHEEL_DIAMETER);
 
     public static final Translation2d[] wheelPositions = {
-            new Translation2d(robotLength / 2, robotWidth / 2),   //FL
-            new Translation2d(robotLength / 2, -robotWidth / 2),   //FR
-            new Translation2d(-robotLength / 2, robotWidth / 2),  //RL
-            new Translation2d(-robotLength / 2, -robotWidth / 2)}; //RR
+        new Translation2d(robotLength / 2, robotWidth / 2), // FL
+        new Translation2d(robotLength / 2, -robotWidth / 2), // FR
+        new Translation2d(-robotLength / 2, robotWidth / 2), // RL
+        new Translation2d(-robotLength / 2, -robotWidth / 2)
+    }; // RR
 
     public static final double MAX_VELOCITY_AUTO = 4.0;
     public static final double MAX_ACCELERATION_AUTO = 2.5;

--- a/src/main/java/frc/robot/swerve/SwerveDrive.java
+++ b/src/main/java/frc/robot/swerve/SwerveDrive.java
@@ -9,36 +9,33 @@ import lib.Utils;
 import lib.math.differential.Derivative;
 import org.littletonrobotics.junction.Logger;
 
-
 public class SwerveDrive extends SubsystemBase {
     private static SwerveDrive INSTANCE = null;
     private final GyroIO gyro;
-    private final SwerveModule[] modules = new SwerveModule[4]; //FL, FR, RL, RR
+    private final SwerveModule[] modules = new SwerveModule[4]; // FL, FR, RL, RR
     private final LinearFilter accelFilter = LinearFilter.movingAverage(15);
-    private final SwerveDriveKinematics kinematics = new SwerveDriveKinematics(
-            SwerveConstants.wheelPositions[0],
-            SwerveConstants.wheelPositions[1],
-            SwerveConstants.wheelPositions[2],
-            SwerveConstants.wheelPositions[3]
-    );
+    private final SwerveDriveKinematics kinematics =
+            new SwerveDriveKinematics(
+                    SwerveConstants.wheelPositions[0],
+                    SwerveConstants.wheelPositions[1],
+                    SwerveConstants.wheelPositions[2],
+                    SwerveConstants.wheelPositions[3]);
     private final SwerveDriveOdometry odometry;
     private final Derivative acceleration = new Derivative();
     private final SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
     private final SwerveDriveInputsAutoLogged loggerInputs = new SwerveDriveInputsAutoLogged();
     private final SwerveModuleState[] currentModuleStates = new SwerveModuleState[4];
 
-    private SwerveDrive(boolean isReal,
-                        int[] driveIds,
-                        int[] angleIds,
-                        int[] encoderIds) {
+    private SwerveDrive(boolean isReal, int[] driveIds, int[] angleIds, int[] encoderIds) {
         if (isReal) {
             for (int i = 0; i < modules.length; i++) {
-                ModuleIO io = new ModuleIOReal(
-                        driveIds[i],
-                        angleIds[i],
-                        encoderIds[i],
-                        SwerveConstants.motionMagicConfigs[i],
-                        i + 1);
+                ModuleIO io =
+                        new ModuleIOReal(
+                                driveIds[i],
+                                angleIds[i],
+                                encoderIds[i],
+                                SwerveConstants.motionMagicConfigs[i],
+                                i + 1);
 
                 modules[i] = new SwerveModule(io, i + 1);
             }
@@ -54,20 +51,15 @@ public class SwerveDrive extends SubsystemBase {
         }
 
         updateModulePositions();
-        odometry = new SwerveDriveOdometry(
-                kinematics, new Rotation2d(getYaw()),
-                modulePositions
-        );
+        odometry = new SwerveDriveOdometry(kinematics, new Rotation2d(getYaw()), modulePositions);
     }
 
     public static SwerveDrive getInstance() {
         return INSTANCE;
     }
 
-    public static void setInstance(boolean isReal,
-                                   int[] driveIds,
-                                   int[] angleIds,
-                                   int[] encoderIds) {
+    public static void setInstance(
+            boolean isReal, int[] driveIds, int[] angleIds, int[] encoderIds) {
         if (INSTANCE == null) {
             INSTANCE = new SwerveDrive(isReal, driveIds, angleIds, encoderIds);
         }
@@ -187,14 +179,14 @@ public class SwerveDrive extends SubsystemBase {
     public void drive(ChassisSpeeds chassisSpeeds, boolean fieldOriented) {
         loggerInputs.desiredSpeeds = Utils.chassisSpeedsToArray(chassisSpeeds);
 
-        ChassisSpeeds fieldOrientedChassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(
-                chassisSpeeds.vxMetersPerSecond,
-                chassisSpeeds.vyMetersPerSecond,
-                chassisSpeeds.omegaRadiansPerSecond,
-                new Rotation2d(getYaw())
-        );
+        ChassisSpeeds fieldOrientedChassisSpeeds =
+                ChassisSpeeds.fromFieldRelativeSpeeds(
+                        chassisSpeeds.vxMetersPerSecond,
+                        chassisSpeeds.vyMetersPerSecond,
+                        chassisSpeeds.omegaRadiansPerSecond,
+                        new Rotation2d(getYaw()));
 
-        if (chassisSpeeds.equals(new ChassisSpeeds(0, 0, 0))) {
+        if (new ChassisSpeeds(0, 0, 0).equals(chassisSpeeds)) {
             for (SwerveModule module : modules) {
                 module.neutralOutput();
             }
@@ -210,15 +202,16 @@ public class SwerveDrive extends SubsystemBase {
     /**
      * Sets the desired percentage of x, y and omega speeds for the frc.robot.swerve
      *
-     * @param xOutput     percentage of the x speed
-     * @param yOutput     percentage of the y speed
+     * @param xOutput percentage of the x speed
+     * @param yOutput percentage of the y speed
      * @param omegaOutput percentage of the omega speed
      */
     public void drive(double xOutput, double yOutput, double omegaOutput, boolean fieldOriented) {
-        ChassisSpeeds chassisSpeeds = new ChassisSpeeds(
-                SwerveConstants.MAX_X_Y_VELOCITY * xOutput,
-                SwerveConstants.MAX_X_Y_VELOCITY * yOutput,
-                SwerveConstants.MAX_OMEGA_VELOCITY * omegaOutput); //removed angleFF
+        ChassisSpeeds chassisSpeeds =
+                new ChassisSpeeds(
+                        SwerveConstants.MAX_X_Y_VELOCITY * xOutput,
+                        SwerveConstants.MAX_X_Y_VELOCITY * yOutput,
+                        SwerveConstants.MAX_OMEGA_VELOCITY * omegaOutput); // removed angleFF
 
         drive(chassisSpeeds, fieldOriented);
     }
@@ -245,29 +238,38 @@ public class SwerveDrive extends SubsystemBase {
                                     currentModuleStates[0],
                                     currentModuleStates[1],
                                     currentModuleStates[2],
-                                    currentModuleStates[3]
-                            ))[i];
+                                    currentModuleStates[3]))[i];
         }
 
-        loggerInputs.linearVelocity = Math.hypot(loggerInputs.currentSpeeds[0], loggerInputs.currentSpeeds[1]);
+        loggerInputs.linearVelocity =
+                Math.hypot(loggerInputs.currentSpeeds[0], loggerInputs.currentSpeeds[1]);
 
         acceleration.update(loggerInputs.linearVelocity);
         loggerInputs.acceleration = accelFilter.calculate(acceleration.get());
 
         loggerInputs.supplyCurrent =
-                modules[0].getSupplyCurrent() + modules[1].getSupplyCurrent() + modules[2].getSupplyCurrent() + modules[3].getStatorCurrent();
+                modules[0].getSupplyCurrent()
+                        + modules[1].getSupplyCurrent()
+                        + modules[2].getSupplyCurrent()
+                        + modules[3].getStatorCurrent();
 
         loggerInputs.statorCurrent =
-                modules[0].getStatorCurrent() + modules[1].getStatorCurrent() + modules[2].getStatorCurrent() + modules[3].getStatorCurrent();
+                modules[0].getStatorCurrent()
+                        + modules[1].getStatorCurrent()
+                        + modules[2].getStatorCurrent()
+                        + modules[3].getStatorCurrent();
 
         loggerInputs.rawYaw = gyro.getRawYaw();
         loggerInputs.yaw = gyro.getYaw();
         loggerInputs.pitch = gyro.getPitch();
         gyro.updateInputs(loggerInputs);
 
-        SwerveDriveKinematics.desaturateWheelSpeeds(Utils.arrayToSwerveModuleStates(loggerInputs.desiredModuleStates), SwerveConstants.MAX_X_Y_VELOCITY); //TODO: may not work
+        SwerveDriveKinematics.desaturateWheelSpeeds(
+                Utils.arrayToSwerveModuleStates(loggerInputs.desiredModuleStates),
+                SwerveConstants.MAX_X_Y_VELOCITY); // TODO: may not work
         for (int i = 0; i < modules.length; i++) {
-            modules[i].setModuleState(Utils.arrayToSwerveModuleStates(loggerInputs.desiredModuleStates)[i]);
+            modules[i].setModuleState(
+                    Utils.arrayToSwerveModuleStates(loggerInputs.desiredModuleStates)[i]);
         }
 
         Logger.processInputs("SwerveDrive", loggerInputs);

--- a/src/main/java/frc/robot/swerve/SwerveDriveInputs.java
+++ b/src/main/java/frc/robot/swerve/SwerveDriveInputs.java
@@ -27,5 +27,5 @@ public class SwerveDriveInputs {
     public double error;
     public double pidSetpoint;
 
-    public double[] botPose = {0, 0, 0}; //x, y, rotation
+    public double[] botPose = {0, 0, 0}; // x, y, rotation
 }

--- a/src/main/java/frc/robot/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/swerve/SwerveModule.java
@@ -54,8 +54,7 @@ public class SwerveModule extends SubsystemBase {
      */
     public SwerveModulePosition getModulePosition() {
         return new SwerveModulePosition(
-                loggerInputs.moduleDistance, new Rotation2d(loggerInputs.angle)
-        );
+                loggerInputs.moduleDistance, new Rotation2d(loggerInputs.angle));
     }
 
     /**
@@ -108,9 +107,7 @@ public class SwerveModule extends SubsystemBase {
 
     @Override
     public void periodic() {
-        currentModuleState = new SwerveModuleState(
-                io.getVelocity(), new Rotation2d(io.getAngle())
-        );
+        currentModuleState = new SwerveModuleState(io.getVelocity(), new Rotation2d(io.getAngle()));
 
         io.updateInputs(loggerInputs);
 

--- a/src/main/java/frc/robot/swerve/commands/JoystickDrive.java
+++ b/src/main/java/frc/robot/swerve/commands/JoystickDrive.java
@@ -23,7 +23,6 @@ public class JoystickDrive extends Command {
                 MathUtil.applyDeadband(-joystick1.getY(), 0.1),
                 MathUtil.applyDeadband(-joystick1.getX(), 0.1),
                 MathUtil.applyDeadband(-joystick2.getX(), 0.1),
-                true
-        );
+                true);
     }
 }

--- a/src/main/java/frc/robot/swerve/commands/KeyboardDriveSim.java
+++ b/src/main/java/frc/robot/swerve/commands/KeyboardDriveSim.java
@@ -20,11 +20,6 @@ public class KeyboardDriveSim extends Command {
         double yOutput = -controller.getRawAxis(0);
         double omegaOutput = controller.getRawAxis(2);
 
-        drive.drive(
-                xOutput,
-                yOutput,
-                omegaOutput,
-                true
-        );
+        drive.drive(xOutput, yOutput, omegaOutput, true);
     }
 }

--- a/src/main/java/frc/robot/swerve/commands/XboxDrive.java
+++ b/src/main/java/frc/robot/swerve/commands/XboxDrive.java
@@ -22,7 +22,6 @@ public class XboxDrive extends Command {
                 MathUtil.applyDeadband(-xboxController.getLeftY(), SwerveConstants.XBOX_DEADBAND),
                 MathUtil.applyDeadband(-xboxController.getLeftX(), SwerveConstants.XBOX_DEADBAND),
                 MathUtil.applyDeadband(-xboxController.getRightX(), SwerveConstants.XBOX_DEADBAND),
-                true
-        );
+                true);
     }
 }

--- a/src/main/java/lib/Utils.java
+++ b/src/main/java/lib/Utils.java
@@ -1,7 +1,6 @@
 package lib;
 
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
@@ -18,19 +17,17 @@ public class Utils {
     }
 
     public static double[] pose2dToArray(Pose2d pose) {
-        return new double[]{pose.getX(), pose.getY(), pose.getRotation().getRadians()};
+        return new double[] {pose.getX(), pose.getY(), pose.getRotation().getRadians()};
     }
 
     public static Pose2d arrayToPose2d(double[] array) {
-        return new Pose2d(
-                array[0],
-                array[1],
-                new Rotation2d(array[2])
-        );
+        return new Pose2d(array[0], array[1], new Rotation2d(array[2]));
     }
 
     public static double[] chassisSpeedsToArray(ChassisSpeeds speeds) {
-        return new double[]{speeds.vxMetersPerSecond, speeds.vyMetersPerSecond, speeds.omegaRadiansPerSecond};
+        return new double[] {
+            speeds.vxMetersPerSecond, speeds.vyMetersPerSecond, speeds.omegaRadiansPerSecond
+        };
     }
 
     public static ChassisSpeeds arrayToChassisSpeeds(double[] array) {
@@ -46,17 +43,18 @@ public class Utils {
         return array;
     }
 
-    public static SwerveModuleState[] arrayToSwerveModuleStates(double[] states) { //TODO: check
+    public static SwerveModuleState[] arrayToSwerveModuleStates(double[] states) { // TODO: check
         SwerveModuleState[] swerveModuleStates = new SwerveModuleState[states.length / 2];
         for (int i = 0; i < states.length; i += 2) {
-            swerveModuleStates[i / 2] = new SwerveModuleState(states[i + 1], new Rotation2d(states[i]));
+            swerveModuleStates[i / 2] =
+                    new SwerveModuleState(states[i + 1], new Rotation2d(states[i]));
         }
         return swerveModuleStates;
     }
 
     public static boolean speedsEpsilonEquals(ChassisSpeeds speeds) {
-        return epsilonEquals(speeds.vxMetersPerSecond, 0) &&
-                epsilonEquals(speeds.vyMetersPerSecond, 0) &&
-                epsilonEquals(speeds.omegaRadiansPerSecond, 0);
+        return epsilonEquals(speeds.vxMetersPerSecond, 0)
+                && epsilonEquals(speeds.vyMetersPerSecond, 0)
+                && epsilonEquals(speeds.omegaRadiansPerSecond, 0);
     }
 }

--- a/src/main/java/lib/controllers/DieterController.java
+++ b/src/main/java/lib/controllers/DieterController.java
@@ -1,6 +1,7 @@
 package lib.controllers;
 
 import edu.wpi.first.math.controller.PIDController;
+import java.util.stream.Stream;
 import lib.Utils;
 
 /*
@@ -14,24 +15,31 @@ public class DieterController extends PIDController {
     private double kDieter;
     // The dead zone of the bang-bang controller
     private double dieterBand = 0;
+    private int a = 9;
 
     /**
      * Constructor for DieterController.
      *
-     * @param kp      The proportional gain.
-     * @param ki      The integral gain.
-     * @param kd      The derivative gain.
+     * @param kp The proportional gain.
+     * @param ki The integral gain.
+     * @param kd The derivative gain.
      * @param kDieter The Dieter constant.
-     * @param period  The period of the controller.
+     * @param period The period of the controller.
      */
     public DieterController(double kp, double ki, double kd, double kDieter, double period) {
         super(kp, ki, kd, period);
         this.kDieter = kDieter;
     }
 
+    public final int x = 0;
+
     public DieterController(double kp, double ki, double kd, double kDieter) {
         super(kp, ki, kd);
         this.kDieter = kDieter;
+        Stream.of("1", 2);
+        int i = 2;
+        i = i + 3;
+        System.out.println(i > 2 ? i : i + 1);
     }
 
     /**
@@ -46,14 +54,17 @@ public class DieterController extends PIDController {
     /**
      * Updates the PIDF constants.
      *
-     * @param kP      The new proportional gain.
-     * @param kI      The new integral gain.
-     * @param kD      The new derivative gain.
+     * @param kP The new proportional gain.
+     * @param kI The new integral gain.
+     * @param kD The new derivative gain.
      * @param kDieter The new Dieter constant.
      */
     public void setPIDF(double kP, double kI, double kD, double kDieter) {
         setPID(kP, kI, kD);
         setDieter(kDieter);
+        Stream.of("1", 2);
+        int i = 0;
+        i += 3;
     }
 
     /**

--- a/src/main/java/lib/math/AngleUtil.java
+++ b/src/main/java/lib/math/AngleUtil.java
@@ -21,12 +21,16 @@ public class AngleUtil {
 
     public static final CoordinateSystem RIGHT_COUNTER_CLOCKWISE = CoordinateSystem.of(0, false);
     public static final CoordinateSystem RIGHT_CLOCKWISE = CoordinateSystem.of(0, true);
-    public static final CoordinateSystem UP_COUNTER_CLOCKWISE = CoordinateSystem.of(Math.PI / 2, false);
+    public static final CoordinateSystem UP_COUNTER_CLOCKWISE =
+            CoordinateSystem.of(Math.PI / 2, false);
     public static final CoordinateSystem UP_CLOCKWISE = CoordinateSystem.of(Math.PI / 2, true);
-    public static final CoordinateSystem LEFT_COUNTER_CLOCKWISE = CoordinateSystem.of(Math.PI, false);
+    public static final CoordinateSystem LEFT_COUNTER_CLOCKWISE =
+            CoordinateSystem.of(Math.PI, false);
     public static final CoordinateSystem LEFT_CLOCKWISE = CoordinateSystem.of(Math.PI, true);
-    public static final CoordinateSystem DOWN_COUNTER_CLOCKWISE = CoordinateSystem.of(3 * Math.PI / 2, false);
-    public static final CoordinateSystem DOWN_CLOCKWISE = CoordinateSystem.of(3 * Math.PI / 2, true);
+    public static final CoordinateSystem DOWN_COUNTER_CLOCKWISE =
+            CoordinateSystem.of(3 * Math.PI / 2, false);
+    public static final CoordinateSystem DOWN_CLOCKWISE =
+            CoordinateSystem.of(3 * Math.PI / 2, true);
 
     public static double normalize(double angle) {
         while (angle < 0) {
@@ -47,11 +51,13 @@ public class AngleUtil {
         return Rotation2d.fromRadians(absoluteAngleToYaw(angle.getRadians()));
     }
 
-    public static double getAbsoluteAngle(ZeroVector zeroVector, ThetaDirection thetaDirection, double angle) {
+    public static double getAbsoluteAngle(
+            ZeroVector zeroVector, ThetaDirection thetaDirection, double angle) {
         return getAbsoluteAngle(new CoordinateSystem(zeroVector, thetaDirection), angle);
     }
 
-    public static double getAbsoluteAngle(double zeroVector, ThetaDirection thetaDirection, double angle) {
+    public static double getAbsoluteAngle(
+            double zeroVector, ThetaDirection thetaDirection, double angle) {
         return getAbsoluteAngle(new CoordinateSystem(zeroVector, thetaDirection), angle);
     }
 
@@ -70,13 +76,20 @@ public class AngleUtil {
         }
 
         public static ThetaDirection of(boolean invert) {
-            return invert ? CLOCKWISE : COUNTER_CLOCKWISE;
+            if (invert) {
+                return CLOCKWISE;
+            } else {
+                return COUNTER_CLOCKWISE;
+            }
         }
 
         public int get() {
-            return clockwise ? -1 : 1;
+            if (clockwise) {
+                return -1;
+            } else {
+                return 1;
+            }
         }
-
     }
 
     public static class Angle {
@@ -102,8 +115,8 @@ public class AngleUtil {
 
         public double getAbsoluteAngle() {
             double absoluteAngle =
-                    coordinateSystem.zeroVector.zeroAbsoluteAngle +
-                            coordinateSystem.thetaDirection.get() * value;
+                    coordinateSystem.zeroVector.zeroAbsoluteAngle
+                            + coordinateSystem.thetaDirection.get() * value;
             return normalize(absoluteAngle);
         }
 
@@ -117,11 +130,14 @@ public class AngleUtil {
 
         @Override
         public String toString() {
-            return "Angle: \n" +
-                    "   Coordinate System: " +
-                    coordinateSystem.zeroVector.toString() + ", " +
-                    coordinateSystem.thetaDirection.name() + "\n" +
-                    "   Value: " + value;
+            return "Angle: \n"
+                    + "   Coordinate System: "
+                    + coordinateSystem.zeroVector.toString()
+                    + ", "
+                    + coordinateSystem.thetaDirection.name()
+                    + "\n"
+                    + "   Value: "
+                    + value;
         }
     }
 
@@ -139,10 +155,7 @@ public class AngleUtil {
         }
 
         public static CoordinateSystem of(double zeroVector, boolean clockwise) {
-            return new CoordinateSystem(
-                    new ZeroVector(zeroVector),
-                    ThetaDirection.of(clockwise)
-            );
+            return new CoordinateSystem(new ZeroVector(zeroVector), ThetaDirection.of(clockwise));
         }
     }
 

--- a/src/main/java/lib/math/Interpolable.java
+++ b/src/main/java/lib/math/Interpolable.java
@@ -1,8 +1,9 @@
 package lib.math;
 
 /**
- * Interpolable is an interface used by an Interpolating Tree as the Value type. Given two end points and an
- * interpolation parameter on [0, 1], it calculates a new Interpolable representing the interpolated value.
+ * Interpolable is an interface used by an Interpolating Tree as the Value type. Given two end
+ * points and an interpolation parameter on [0, 1], it calculates a new Interpolable representing
+ * the interpolated value.
  *
  * @param <T> The Type of Interpolable
  * @see InterpolatingTreeMap
@@ -10,12 +11,12 @@ package lib.math;
 public interface Interpolable<T> {
 
     /**
-     * Interpolates between this value and an other value according to a given parameter. If x is 0, the method should
-     * return this value. If x is 1, the method should return the other value. If 0 < x < 1, the return value should be
-     * interpolated proportionally between the two.
+     * Interpolates between this value and an other value according to a given parameter. If x is 0,
+     * the method should return this value. If x is 1, the method should return the other value. If
+     * 0 < x < 1, the return value should be interpolated proportionally between the two.
      *
      * @param other The value of the upper bound
-     * @param x     The requested value. Should be between 0 and 1.
+     * @param x The requested value. Should be between 0 and 1.
      * @return Interpolable<T> The estimated average between the surrounding data
      */
     T interpolate(T other, double x);

--- a/src/main/java/lib/math/InterpolatingDouble.java
+++ b/src/main/java/lib/math/InterpolatingDouble.java
@@ -5,8 +5,10 @@ package lib.math;
  *
  * @see InterpolatingTreeMap
  */
-public class InterpolatingDouble implements Interpolable<InterpolatingDouble>, InverseInterpolable<InterpolatingDouble>,
-        Comparable<InterpolatingDouble> {
+public class InterpolatingDouble
+        implements Interpolable<InterpolatingDouble>,
+                InverseInterpolable<InterpolatingDouble>,
+                Comparable<InterpolatingDouble> {
 
     public double value;
 

--- a/src/main/java/lib/math/InterpolatingDoubleMap.java
+++ b/src/main/java/lib/math/InterpolatingDoubleMap.java
@@ -1,14 +1,13 @@
 package lib.math;
 
-public class InterpolatingDoubleMap extends InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble> {
+public class InterpolatingDoubleMap
+        extends InterpolatingTreeMap<InterpolatingDouble, InterpolatingDouble> {
 
     public InterpolatingDoubleMap(int maximumSize) {
         super(maximumSize);
     }
 
-    public InterpolatingDoubleMap() {
-        super();
-    }
+    public InterpolatingDoubleMap() {}
 
     public InterpolatingDouble put(double a, double b) {
         return super.put(new InterpolatingDouble(a), new InterpolatingDouble(b));

--- a/src/main/java/lib/math/InterpolatingTreeMap.java
+++ b/src/main/java/lib/math/InterpolatingTreeMap.java
@@ -4,13 +4,14 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Interpolating Tree Maps are used to get values at points that are not defined by making a guess from points that are
- * defined. This uses linear interpolation.
+ * Interpolating Tree Maps are used to get values at points that are not defined by making a guess
+ * from points that are defined. This uses linear interpolation.
  *
  * @param <K> The type of the key (must implement InverseInterpolable)
  * @param <V> The type of the value (must implement Interpolable)
  */
-public class InterpolatingTreeMap<K extends InverseInterpolable<K> & Comparable<K>, V extends Interpolable<V>>
+public class InterpolatingTreeMap<
+                K extends InverseInterpolable<K> & Comparable<K>, V extends Interpolable<V>>
         extends TreeMap<K, V> {
 
     private static final long serialVersionUID = 8347275262778054124L;
@@ -28,7 +29,7 @@ public class InterpolatingTreeMap<K extends InverseInterpolable<K> & Comparable<
     /**
      * Inserts a key value pair, and trims the tree if a max size is specified
      *
-     * @param key   Key for inserted data
+     * @param key Key for inserted data
      * @param value Value for inserted data
      * @return the value
      */
@@ -52,7 +53,8 @@ public class InterpolatingTreeMap<K extends InverseInterpolable<K> & Comparable<
 
     /**
      * @param key Lookup for a value (does not have to exist)
-     * @return V or null; V if it is Interpolable or exists, null if it is at a bound and cannot average
+     * @return V or null; V if it is Interpolable or exists, null if it is at a bound and cannot
+     *     average
      */
     public V getInterpolated(K key) {
         V gotval = get(key);

--- a/src/main/java/lib/math/InverseInterpolable.java
+++ b/src/main/java/lib/math/InverseInterpolable.java
@@ -1,9 +1,9 @@
 package lib.math;
 
 /**
- * InverseInterpolable is an interface used by an Interpolating Tree as the Key type. Given two endpoint keys and a
- * third query key, an InverseInterpolable object can calculate the interpolation parameter of the query key on the
- * interval [0, 1].
+ * InverseInterpolable is an interface used by an Interpolating Tree as the Key type. Given two
+ * endpoint keys and a third query key, an InverseInterpolable object can calculate the
+ * interpolation parameter of the query key on the interval [0, 1].
  *
  * @param <T> The Type of InverseInterpolable
  * @see InterpolatingTreeMap
@@ -11,11 +11,11 @@ package lib.math;
 public interface InverseInterpolable<T> {
 
     /**
-     * Given this point (lower), a query point (query), and an upper point (upper), estimate how far (on [0, 1]) between
-     * 'lower' and 'upper' the query point lies.
+     * Given this point (lower), a query point (query), and an upper point (upper), estimate how far
+     * (on [0, 1]) between 'lower' and 'upper' the query point lies.
      *
-     * @return The interpolation parameter on [0, 1] representing how far between this point and the upper point the
-     * query point lies.
+     * @return The interpolation parameter on [0, 1] representing how far between this point and the
+     *     upper point the query point lies.
      */
     double inverseInterpolate(T upper, T query);
 }

--- a/src/main/java/lib/math/Rotation2.java
+++ b/src/main/java/lib/math/Rotation2.java
@@ -1,55 +1,48 @@
 package lib.math;
 
-import lib.Utils;
-
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.Objects;
+import lib.Utils;
 
 /**
- * A rotation is a representation of an angle by trigonometric functions. This is useful because it allows for easy
- * mathematical calculations as the sine and cosine of the angle are already calculated. One benefit of this is that
- * there is no need to convert between degrees and radians.
+ * A rotation is a representation of an angle by trigonometric functions. This is useful because it
+ * allows for easy mathematical calculations as the sine and cosine of the angle are already
+ * calculated. One benefit of this is that there is no need to convert between degrees and radians.
  *
  * @since 0.2
  */
 public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
 
-    /**
-     * A rotation which represents an angle of 0 degrees.
-     */
+    /** A rotation which represents an angle of 0 degrees. */
     public static final Rotation2 ZERO = new Rotation2(1, 0, false);
 
     private static final long serialVersionUID = -6995694984676493861L;
 
-    /**
-     * The cosine of the angle.
-     */
+    /** The cosine of the angle. */
     public final double cos;
 
-    /**
-     * The sine of the angle.
-     */
+    /** The sine of the angle. */
     public final double sin;
 
-    /**
-     * The tangent of the angle.
-     */
+    /** The tangent of the angle. */
     public final double tan;
 
     /**
      * Create a new rotation from a point, normalizing it to be on the unit circle if necessary.
      *
-     * @param x         The x coordinate or cosine.
-     * @param y         The y coordinate or sine.
-     * @param normalize Whether or not to normalize the x and y coordinates. Should be set to true if it is uncertain
-     *                  if the point is on the unit circle.
+     * @param x The x coordinate or cosine.
+     * @param y The y coordinate or sine.
+     * @param normalize Whether or not to normalize the x and y coordinates. Should be set to true
+     *     if it is uncertain if the point is on the unit circle.
      */
     public Rotation2(double x, double y, boolean normalize) {
         if (normalize) {
             double length = Math.sqrt(x * x + y * y);
 
-            // If the length is so small that we are unsure if the point has a direction, default to an angle of 0 degrees.
+            // If the length is so small that we are unsure if the point has a direction, default to
+            // an
+            // angle of 0 degrees.
             if (length > Utils.EPSILON) {
                 x /= length;
                 y /= length;
@@ -62,7 +55,9 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
         this.cos = x;
         this.sin = y;
 
-        // Tangent has special cases if the cosine of the angle is 0 (Straight up on the unit circle or straight down).
+        // Tangent has special cases if the cosine of the angle is 0 (Straight up on the unit circle
+        // or
+        // straight down).
         if (Utils.epsilonEquals(cos, 0.0)) {
             if (sin >= 0) {
                 this.tan = Double.POSITIVE_INFINITY;
@@ -125,16 +120,17 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
      * @return The rotation rotated by the other rotation.
      */
     public Rotation2 rotateBy(Rotation2 other) {
-        // This is implemented as a rotation matrix. The rotation "this" is rotated by a rotation matrix created by the
+        // This is implemented as a rotation matrix. The rotation "this" is rotated by a rotation
+        // matrix created by the
         // rotation "other".
-        // See https://en.wikipedia.org/wiki/Rotation_matrix for more information on rotation matrices.
-        return new Rotation2(cos * other.cos - sin * other.sin,
-                cos * other.sin + sin * other.cos, true);
+        // See https://en.wikipedia.org/wiki/Rotation_matrix for more information on rotation
+        // matrices.
+        return new Rotation2(
+                cos * other.cos - sin * other.sin, cos * other.sin + sin * other.cos, true);
     }
 
     /**
-     * Calculate the normal this rotation.
-     * The normal is perpendicular to this rotation.
+     * Calculate the normal this rotation. The normal is perpendicular to this rotation.
      *
      * @return The normal of this rotation.
      */
@@ -153,9 +149,9 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
 
     /**
      * Check whether this rotation is parallel to another rotation.
-     * <p>
-     * This is different from {@link #equals} because it also takes into account rotations that are facing the opposite
-     * direction.
+     *
+     * <p>This is different from {@link #equals} because it also takes into account rotations that
+     * are facing the opposite direction.
      *
      * @param other The rotation to check if it is parallel with.
      * @return If the rotations are parallel.
@@ -164,9 +160,7 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
         return Utils.epsilonEquals(Vector2.fromAngle(this).cross(Vector2.fromAngle(other)), 0.0);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Rotation2 interpolate(Rotation2 other, double t) {
         if (t <= 0.0) {
@@ -190,9 +184,7 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
         return Rotation2.fromRadians(from + ((to - from) * t));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Rotation2 other)) {
@@ -203,21 +195,17 @@ public final class Rotation2 implements Interpolable<Rotation2>, Serializable {
     }
 
     public boolean equals(Rotation2 other, double maxError) {
-        return Utils.epsilonEquals(cos, other.cos, Math.abs(Math.cos(maxError))) &&
-                Utils.epsilonEquals(sin, other.sin, Math.abs(Math.sin(maxError)));
+        return Utils.epsilonEquals(cos, other.cos, Math.abs(Math.cos(maxError)))
+                && Utils.epsilonEquals(sin, other.sin, Math.abs(Math.sin(maxError)));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(cos, sin);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         DecimalFormat fmt = new DecimalFormat("#0.000");

--- a/src/main/java/lib/math/Vector2.java
+++ b/src/main/java/lib/math/Vector2.java
@@ -1,11 +1,10 @@
 package lib.math;
 
 import edu.wpi.first.math.MathUtil;
-import lib.Utils;
-
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.Objects;
+import lib.Utils;
 
 /**
  * A vector representing a point in 2d space.
@@ -20,7 +19,9 @@ public final class Vector2 implements Interpolable<Vector2>, Serializable {
      * @since 0.1
      */
     public static final Vector2 ZERO = new Vector2(0, 0);
+
     private static final long serialVersionUID = 7566662924062254722L;
+
     /**
      * The x coordinate of the vector
      *
@@ -205,7 +206,8 @@ public final class Vector2 implements Interpolable<Vector2>, Serializable {
     }
 
     /**
-     * Calculates the cross product of this vector and another vector in 3d space and returns the length.
+     * Calculates the cross product of this vector and another vector in 3d space and returns the
+     * length.
      *
      * @param other The other vector to calculate the cross product with
      * @return The length of the calculated vector
@@ -223,12 +225,11 @@ public final class Vector2 implements Interpolable<Vector2>, Serializable {
      * @since 0.2
      */
     public Vector2 rotateBy(Rotation2 rotation) {
-        return new Vector2(x * rotation.cos - y * rotation.sin, x * rotation.sin + y * rotation.cos);
+        return new Vector2(
+                x * rotation.cos - y * rotation.sin, x * rotation.sin + y * rotation.cos);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Vector2)) {
@@ -239,21 +240,17 @@ public final class Vector2 implements Interpolable<Vector2>, Serializable {
     }
 
     public boolean equals(Vector2 other, double allowableError) {
-        return Utils.epsilonEquals(x, other.x, allowableError) &&
-                Utils.epsilonEquals(y, other.y, allowableError);
+        return Utils.epsilonEquals(x, other.x, allowableError)
+                && Utils.epsilonEquals(y, other.y, allowableError);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(x, y);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         DecimalFormat fmt = new DecimalFormat("#0.000");

--- a/src/main/java/lib/math/differential/BooleanTrigger.java
+++ b/src/main/java/lib/math/differential/BooleanTrigger.java
@@ -14,11 +14,8 @@ public class BooleanTrigger {
     // Whether the trigger has been released
     private boolean released = false;
 
-    /**
-     * Constructor for BooleanTrigger.
-     */
-    public BooleanTrigger() {
-    }
+    /** Constructor for BooleanTrigger. */
+    public BooleanTrigger() {}
 
     /**
      * Updates the trigger.

--- a/src/main/java/lib/math/differential/Derivative.java
+++ b/src/main/java/lib/math/differential/Derivative.java
@@ -19,11 +19,8 @@ public class Derivative {
     // The derivative of the derivative
     private Derivative derivative = null;
 
-    /**
-     * Constructor for Derivative.
-     */
-    public Derivative() {
-    }
+    /** Constructor for Derivative. */
+    public Derivative() {}
 
     /**
      * Gets the derivative of the derivative.
@@ -49,7 +46,7 @@ public class Derivative {
     /**
      * Updates the value to differentiate.
      *
-     * @param newValue  The new value to differentiate.
+     * @param newValue The new value to differentiate.
      * @param timestamp The current timestamp. [s]
      */
     public void update(double newValue, double timestamp) {

--- a/src/main/java/lib/math/differential/Integral.java
+++ b/src/main/java/lib/math/differential/Integral.java
@@ -20,11 +20,8 @@ public class Integral {
     // The integral of the integral
     private Integral integral = null;
 
-    /**
-     * Constructor for Integral.
-     */
-    public Integral() {
-    }
+    /** Constructor for Integral. */
+    public Integral() {}
 
     /**
      * Gets the integral of the integral.
@@ -50,7 +47,7 @@ public class Integral {
     /**
      * Updates the value to integrate.
      *
-     * @param newValue  The new value to integrate.
+     * @param newValue The new value to integrate.
      * @param timestamp The current timestamp. [s]
      */
     public void update(double newValue, double timestamp) {

--- a/src/main/java/lib/motors/SparkMaxSim.java
+++ b/src/main/java/lib/motors/SparkMaxSim.java
@@ -38,13 +38,15 @@ public class SparkMaxSim extends SimMotor {
                 setInputVoltage(controller.calculate(getPosition(), value) + arbFeedforward);
                 break;
             case kSmartMotion:
-                setInputVoltage(profiledController.calculate(getPosition(), value) + arbFeedforward);
+                setInputVoltage(
+                        profiledController.calculate(getPosition(), value) + arbFeedforward);
                 break;
             case kVelocity:
                 setInputVoltage(controller.calculate(getVelocity(), value) + arbFeedforward);
                 break;
             case kSmartVelocity:
-                setInputVoltage(profiledController.calculate(getVelocity(), value) + arbFeedforward);
+                setInputVoltage(
+                        profiledController.calculate(getVelocity(), value) + arbFeedforward);
                 break;
             case kVoltage:
                 setInputVoltage(value);

--- a/src/main/java/lib/motors/TalonFXSim.java
+++ b/src/main/java/lib/motors/TalonFXSim.java
@@ -30,38 +30,42 @@ public class TalonFXSim extends SimMotor {
     }
 
     public void setControl(PositionDutyCycle request) {
-        voltageRequest = controller.calculate(
-                motorSim.getAngularPositionRotations(), request.Position);
+        voltageRequest =
+                controller.calculate(motorSim.getAngularPositionRotations(), request.Position);
         this.setControl(new VoltageOut(voltageRequest + 12 * request.FeedForward));
     }
 
     public void setControl(PositionVoltage request) {
-        voltageRequest = controller.calculate(
-                motorSim.getAngularPositionRotations(), request.Position);
+        voltageRequest =
+                controller.calculate(motorSim.getAngularPositionRotations(), request.Position);
         this.setControl(new VoltageOut(voltageRequest + request.FeedForward));
     }
 
     public void setControl(VelocityDutyCycle request) {
-        voltageRequest = controller.calculate(
-                Units.rpmToRps(motorSim.getAngularVelocityRPM()), request.Velocity);
+        voltageRequest =
+                controller.calculate(
+                        Units.rpmToRps(motorSim.getAngularVelocityRPM()), request.Velocity);
         this.setControl(new VoltageOut(voltageRequest + 12 * request.FeedForward));
     }
 
     public void setControl(VelocityVoltage request) {
-        voltageRequest = controller.calculate(
-                Units.rpmToRps(motorSim.getAngularVelocityRPM()), request.Velocity);
+        voltageRequest =
+                controller.calculate(
+                        Units.rpmToRps(motorSim.getAngularVelocityRPM()), request.Velocity);
         this.setControl(new VoltageOut(voltageRequest + request.FeedForward));
     }
 
     public void setControl(MotionMagicDutyCycle request) {
-        voltageRequest = profiledController.calculate(
-                motorSim.getAngularPositionRotations(), request.Position);
+        voltageRequest =
+                profiledController.calculate(
+                        motorSim.getAngularPositionRotations(), request.Position);
         this.setControl(new VoltageOut(voltageRequest + 12 * request.FeedForward));
     }
 
     public void setControl(MotionMagicVoltage request) {
-        voltageRequest = profiledController.calculate(
-                motorSim.getAngularPositionRotations(), request.Position);
+        voltageRequest =
+                profiledController.calculate(
+                        motorSim.getAngularPositionRotations(), request.Position);
         this.setControl(new VoltageOut(voltageRequest + request.FeedForward));
     }
 

--- a/src/main/java/lib/units/Phoenix6UnitModel.java
+++ b/src/main/java/lib/units/Phoenix6UnitModel.java
@@ -10,8 +10,8 @@ public class Phoenix6UnitModel {
     /**
      * Constructor.
      *
-     * @param gearRatio the ratio between the motor and the system.
-     *                  If the gear ratio is larger than 1, it is a reduction.
+     * @param gearRatio the ratio between the motor and the system. If the gear ratio is larger than
+     *     1, it is a reduction.
      */
     public Phoenix6UnitModel(double gearRatio) {
         this.gearRatio = gearRatio;

--- a/src/main/java/lib/webconstants/LoggedTunableNumber.java
+++ b/src/main/java/lib/webconstants/LoggedTunableNumber.java
@@ -1,9 +1,8 @@
 package lib.webconstants;
 
-import org.littletonrobotics.junction.networktables.LoggedDashboardNumber;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.littletonrobotics.junction.networktables.LoggedDashboardNumber;
 
 /**
  * Class for a tunable number. Gets value from dashboard in tuning mode, returns default if not or
@@ -63,7 +62,11 @@ public class LoggedTunableNumber {
         if (!hasDefault) {
             return 0.0;
         } else {
-            return IN_TUNING_MODE ? dashboardNumber.get() : defaultValue;
+            if (IN_TUNING_MODE) {
+                return dashboardNumber.get();
+            } else {
+                return defaultValue;
+            }
         }
     }
 
@@ -71,9 +74,9 @@ public class LoggedTunableNumber {
      * Checks whether the number has changed since our last check
      *
      * @param id Unique identifier for the caller to avoid conflicts when shared between multiple
-     *           objects. Recommended approach is to pass the result of "hashCode()"
+     *     objects. Recommended approach is to pass the result of "hashCode()"
      * @return True if the number has changed since the last time this method was called, false
-     * otherwise.
+     *     otherwise.
      */
     public boolean hasChanged(int id) {
         double currentValue = get();

--- a/src/main/java/tests/TestBooleanTrigger.java
+++ b/src/main/java/tests/TestBooleanTrigger.java
@@ -13,19 +13,11 @@ public class TestBooleanTrigger {
         trigger.update(true);
         trigger.update(false);
 
-        Assertions.assertTrue(
-                trigger.released()
-        );
-        Assertions.assertFalse(
-                trigger.triggered()
-        );
+        Assertions.assertTrue(trigger.released());
+        Assertions.assertFalse(trigger.triggered());
 
         trigger.update(true);
-        Assertions.assertTrue(
-                trigger.triggered()
-        );
-        Assertions.assertFalse(
-                trigger.released()
-        );
+        Assertions.assertTrue(trigger.triggered());
+        Assertions.assertFalse(trigger.released());
     }
 }

--- a/src/main/java/tests/TestDerivative.java
+++ b/src/main/java/tests/TestDerivative.java
@@ -14,35 +14,14 @@ public class TestDerivative {
 
         derivative.update(1, 0);
         derivative.update(1, 1);
-        Assertions.assertEquals(
-                0,
-                derivative.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(0, derivative.get(), Utils.EPSILON);
 
         derivative.update(2, 2);
-        Assertions.assertEquals(
-                1,
-                derivative.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                1,
-                secondDerivative.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(1, derivative.get(), Utils.EPSILON);
+        Assertions.assertEquals(1, secondDerivative.get(), Utils.EPSILON);
 
         derivative.update(1, 3);
-        Assertions.assertEquals(
-                -1,
-                derivative.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                -2,
-                secondDerivative.get(),
-                Utils.EPSILON
-        );
-
+        Assertions.assertEquals(-1, derivative.get(), Utils.EPSILON);
+        Assertions.assertEquals(-2, secondDerivative.get(), Utils.EPSILON);
     }
 }

--- a/src/main/java/tests/TestDieterController.java
+++ b/src/main/java/tests/TestDieterController.java
@@ -12,66 +12,34 @@ public class TestDieterController {
         try (DieterController controller = new DieterController(1, 0, 0, 1)) {
             controller.setDieterBand(0.9);
             double val = controller.calculate(0, 1);
-            Assertions.assertEquals(
-                    2,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(2, val, Utils.EPSILON);
 
             controller.setDieterBand(1.1);
             val = controller.calculate(0, 1);
-            Assertions.assertEquals(
-                    1,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(1, val, Utils.EPSILON);
 
             val = controller.calculate(0, 0);
-            Assertions.assertEquals(
-                    0,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(0, val, Utils.EPSILON);
 
             controller.setP(0);
             val = controller.calculate(0, 1.5);
-            Assertions.assertEquals(
-                    1,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(1, val, Utils.EPSILON);
 
             controller.setPIDF(1, 0, 0, 1);
             controller.setDieterBand(0.9);
             val = controller.calculate(0, -1);
-            Assertions.assertEquals(
-                    -2,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(-2, val, Utils.EPSILON);
 
             controller.setDieterBand(1.1);
             val = controller.calculate(0, -1);
-            Assertions.assertEquals(
-                    -1,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(-1, val, Utils.EPSILON);
 
             val = controller.calculate(0, 0);
-            Assertions.assertEquals(
-                    0,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(0, val, Utils.EPSILON);
 
             controller.setP(Utils.EPSILON / 2);
             val = controller.calculate(0, -1.5);
-            Assertions.assertEquals(
-                    -1,
-                    val,
-                    Utils.EPSILON
-            );
+            Assertions.assertEquals(-1, val, Utils.EPSILON);
         }
     }
 }

--- a/src/main/java/tests/TestIntegral.java
+++ b/src/main/java/tests/TestIntegral.java
@@ -14,62 +14,23 @@ public class TestIntegral {
 
         integral.update(1, 0);
         integral.update(1, 1);
-        Assertions.assertEquals(
-                1,
-                integral.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                0.5,
-                secondIntegral.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(1, integral.get(), Utils.EPSILON);
+        Assertions.assertEquals(0.5, secondIntegral.get(), Utils.EPSILON);
 
         integral.update(2, 2);
-        Assertions.assertEquals(
-                2.5,
-                integral.get()
-        );
-        Assertions.assertEquals(
-                2.25,
-                secondIntegral.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(2.5, integral.get());
+        Assertions.assertEquals(2.25, secondIntegral.get(), Utils.EPSILON);
 
         integral.update(1, 3);
-        Assertions.assertEquals(
-                4,
-                integral.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                5.5,
-                secondIntegral.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(4, integral.get(), Utils.EPSILON);
+        Assertions.assertEquals(5.5, secondIntegral.get(), Utils.EPSILON);
 
         integral.update(0, 4);
-        Assertions.assertEquals(
-                4.5,
-                integral.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                9.75,
-                secondIntegral.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(4.5, integral.get(), Utils.EPSILON);
+        Assertions.assertEquals(9.75, secondIntegral.get(), Utils.EPSILON);
 
         integral.update(-4, 5);
-        Assertions.assertEquals(
-                2.5,
-                integral.get(),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                13.25,
-                secondIntegral.get(),
-                Utils.EPSILON
-        );
+        Assertions.assertEquals(2.5, integral.get(), Utils.EPSILON);
+        Assertions.assertEquals(13.25, secondIntegral.get(), Utils.EPSILON);
     }
 }

--- a/src/main/java/tests/TestUtils.java
+++ b/src/main/java/tests/TestUtils.java
@@ -12,122 +12,77 @@ public class TestUtils {
 
     @Test
     public void testEpsilonEqualsDefaultEpsilon() {
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1, 1)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1, -1)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(0, 0)
-        );
+        Assertions.assertTrue(Utils.epsilonEquals(1, 1));
+        Assertions.assertTrue(Utils.epsilonEquals(-1, -1));
+        Assertions.assertTrue(Utils.epsilonEquals(0, 0));
 
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1 + Utils.EPSILON / 2, 1)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1, 1 + Utils.EPSILON / 2)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1, 1 - Utils.EPSILON / 2)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1 - Utils.EPSILON / 2, 1)
-        );
+        Assertions.assertTrue(Utils.epsilonEquals(1 + Utils.EPSILON / 2, 1));
+        Assertions.assertTrue(Utils.epsilonEquals(1, 1 + Utils.EPSILON / 2));
+        Assertions.assertTrue(Utils.epsilonEquals(1, 1 - Utils.EPSILON / 2));
+        Assertions.assertTrue(Utils.epsilonEquals(1 - Utils.EPSILON / 2, 1));
 
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1 + Utils.EPSILON / 2, -1)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1, -1 + Utils.EPSILON / 2)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1, -1 - Utils.EPSILON / 2)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1 - Utils.EPSILON / 2, -1)
-        );
+        Assertions.assertTrue(Utils.epsilonEquals(-1 + Utils.EPSILON / 2, -1));
+        Assertions.assertTrue(Utils.epsilonEquals(-1, -1 + Utils.EPSILON / 2));
+        Assertions.assertTrue(Utils.epsilonEquals(-1, -1 - Utils.EPSILON / 2));
+        Assertions.assertTrue(Utils.epsilonEquals(-1 - Utils.EPSILON / 2, -1));
     }
 
     @Test
     public void testEpsilonEqualsCustomEpsilon() {
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1, 1.5, 0.5)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1, -1.5, 0.5)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(1.5, 1, 0.5)
-        );
-        Assertions.assertTrue(
-                Utils.epsilonEquals(-1.5, -1, 0.5)
-        );
+        Assertions.assertTrue(Utils.epsilonEquals(1, 1.5, 0.5));
+        Assertions.assertTrue(Utils.epsilonEquals(-1, -1.5, 0.5));
+        Assertions.assertTrue(Utils.epsilonEquals(1.5, 1, 0.5));
+        Assertions.assertTrue(Utils.epsilonEquals(-1.5, -1, 0.5));
     }
 
     @Test
     public void testPose2dConversions() {
         double x = 1, y = 1, rot = 1;
         Pose2d poseObject = new Pose2d(1, 1, new Rotation2d(1));
-        double[] poseArray = new double[]{x, y, rot};
+        double[] poseArray = new double[] {x, y, rot};
 
-        Assertions.assertArrayEquals(
-                poseArray,
-                Utils.pose2dToArray(poseObject),
-                Utils.EPSILON
-        );
-        Assertions.assertEquals(
-                poseObject.toString(),
-                Utils.arrayToPose2d(poseArray).toString()
-        );
+        Assertions.assertArrayEquals(poseArray, Utils.pose2dToArray(poseObject), Utils.EPSILON);
+        Assertions.assertEquals(poseObject.toString(), Utils.arrayToPose2d(poseArray).toString());
     }
 
     @Test
     public void testChassisSpeedsConversions() {
         double x = 1, y = 1, omega = 1;
-        double[] chassisSpeedsArray = new double[]{x, y, omega};
+        double[] chassisSpeedsArray = new double[] {x, y, omega};
         ChassisSpeeds chassisSpeedsObject = new ChassisSpeeds(x, y, omega);
 
         Assertions.assertArrayEquals(
-                chassisSpeedsArray,
-                Utils.chassisSpeedsToArray(chassisSpeedsObject),
-                Utils.EPSILON
-        );
+                chassisSpeedsArray, Utils.chassisSpeedsToArray(chassisSpeedsObject), Utils.EPSILON);
         Assertions.assertEquals(
                 Utils.arrayToChassisSpeeds(chassisSpeedsArray).toString(),
-                chassisSpeedsObject.toString()
-        );
+                chassisSpeedsObject.toString());
     }
 
     @Test
     public void testSwerveModuleConversions() {
         double vel1 = 1, angle1 = 1, vel2 = 2, angle2 = 0.5;
-        double[] swerveModuleStatesArray = new double[]{angle1, vel1, angle2, vel2};
-        SwerveModuleState[] swerveModuleStates = new SwerveModuleState[]{
-                new SwerveModuleState(vel1, new Rotation2d(angle1)),
-                new SwerveModuleState(vel2, new Rotation2d(angle2))
-        };
+        double[] swerveModuleStatesArray = new double[] {angle1, vel1, angle2, vel2};
+        SwerveModuleState[] swerveModuleStates =
+                new SwerveModuleState[] {
+                    new SwerveModuleState(vel1, new Rotation2d(angle1)),
+                    new SwerveModuleState(vel2, new Rotation2d(angle2))
+                };
 
         SwerveModuleState[] convertedSwerveModuleStates =
                 Utils.arrayToSwerveModuleStates(swerveModuleStatesArray);
 
-        Assertions.assertEquals(
-                swerveModuleStates.length,
-                convertedSwerveModuleStates.length
-        );
+        Assertions.assertEquals(swerveModuleStates.length, convertedSwerveModuleStates.length);
         for (int i = 0; i < convertedSwerveModuleStates.length; i++) {
             Assertions.assertEquals(
                     "Module " + (i + 1),
                     swerveModuleStates[i].toString(),
-                    convertedSwerveModuleStates[i].toString()
-            );
+                    convertedSwerveModuleStates[i].toString());
         }
 
         Assertions.assertArrayEquals(
                 swerveModuleStatesArray,
                 Utils.swerveModuleStatesToArray(swerveModuleStates),
-                Utils.EPSILON
-        );
+                Utils.EPSILON);
     }
 
     @Test
@@ -136,14 +91,8 @@ public class TestUtils {
         ChassisSpeeds speeds = new ChassisSpeeds(x, y, omega);
         ChassisSpeeds negativeSpeeds = new ChassisSpeeds(-x, -y, -omega);
 
-        Assertions.assertTrue(
-                Utils.speedsEpsilonEquals(speeds)
-        );
-        Assertions.assertTrue(
-                Utils.speedsEpsilonEquals(negativeSpeeds)
-        );
-        Assertions.assertTrue(
-                Utils.speedsEpsilonEquals(new ChassisSpeeds())
-        );
+        Assertions.assertTrue(Utils.speedsEpsilonEquals(speeds));
+        Assertions.assertTrue(Utils.speedsEpsilonEquals(negativeSpeeds));
+        Assertions.assertTrue(Utils.speedsEpsilonEquals(new ChassisSpeeds()));
     }
 }


### PR DESCRIPTION
This PR introduces [Spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle), a popular formatting plugin for many languages, including Java. This is also the formatter [recommended by WPILib](https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/code-formatting.html#spotless).

Additionally, I added [CleanThat](https://github.com/solven-eu/cleanthat), an auto-formatter that Spotless supports and runs before formatting the code. The way CleanThat works is by going over a given list of "mutators" (refactoring rules) and running them one by one. For example, it turns `Arrays.asList("1", 2).stream()` into `Arrays.stream("1", 2)`. You can see a list of "mutators" CleanThat runs [here](https://github.com/solven-eu/cleanthat/blob/master/MUTATORS.generated.MD).

To check whether the project is formatted correctly, run `./gradlew spotlessCheck` (`spotlessC` works too). To auto-format the code, run `./gradlew spotlessApply` (`spotlessA` works too).