### PR TITLE
Add pre-commit Git hook that runs `spotlessCheck`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,13 @@ publishing {
     }
 }
 
+copy {
+    from "."
+    include "pre-commit"
+    into ".git/hooks"
+    fileMode 0777
+}
+
 spotless {
     format 'misc', {
         // define the files to apply `misc` to

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+# From gist at https://gist.github.com/chadmaughan/5889802
+# Found on https://github.com/diffplug/spotless/issues/178#issuecomment-351638034
+
+echo '[git hook] executing gradle spotlessCheck before commit'
+
+# stash any unstaged changes
+git stash -q --keep-index
+
+# run the spotlessCheck with the gradle wrapper
+./gradlew spotlessCheck --daemon
+
+# store the last exit code in a variable
+RESULT=$?
+
+# unstash the unstashed changes
+git stash pop -q
+
+# return the './gradlew spotlessCheck' exit code
+exit $RESULT


### PR DESCRIPTION
> Like many other Version Control Systems, Git has a way to fire off custom scripts when certain important actions occur. There are two groups of these hooks: client-side and server-side. Client-side hooks are triggered by operations such as committing and merging, while server-side hooks run on network operations such as receiving pushed commits. You can use these hooks for all sorts of reasons.

From the [official Git documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).  
The Git hook added here runs `./gradlew spotlessCheck` before committing. If the code is not formatted correctly, Git won't let the commit finish. Users will need to fix the issues (either manually or using `spotlessApply`) and only then will they be able to commit.

I also added a `copy` task to `build.gradle` that copies the script into the `.git/hooks` directory. This is because hooks can't be saved directly to a repository, so this is an easy way to ensure everyone who commits to this project will have the Git hook (provided they run some Gradle task, which is very likely).